### PR TITLE
use shutdown-evt support for the parallel-compilation lock

### DIFF
--- a/drracket/drracket/private/expanding-place.rkt
+++ b/drracket/drracket/private/expanding-place.rkt
@@ -45,7 +45,8 @@
   (set! module-language-parallel-lock-client
         (compile-lock->parallel-lock-client
          (place-channel-get p)
-         (current-custodian)))
+         (current-custodian)
+         current-parallel-lock-shutdown-evt))
   
   ;; get the handlers in a second message
   (set! handlers 

--- a/drracket/drracket/private/module-language.rkt
+++ b/drracket/drracket/private/module-language.rkt
@@ -2710,7 +2710,8 @@
   (define module-language-parallel-lock-client
     (compile-lock->parallel-lock-client
      module-language-compile-lock
-     (current-custodian)))
+     (current-custodian)
+     current-parallel-lock-shutdown-evt))
   
   ;; in-module-language : (or/c top-level-window<%> #f) -> module-language-settings or #f
   (define (in-module-language tlw)

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -5,7 +5,7 @@
 (define deps '("scheme-lib"
                "data-lib"
                "compiler-lib"
-               ["base" #:version "6.2.900.15"]
+               ["base" #:version "8.1.0.7"]
                "planet-lib"
                "compatibility-lib"
                ["draw-lib" #:version "1.7"]


### PR DESCRIPTION
The compilation manager's lock need to know when a thread definitely
will not run any more, even though it has not terminated. A user
thread is never terminated in the `thread-wait` sense, because it is
created with `thread/suspend-to-kill`.

Closes racket/racket#2681