### PR TITLE
add 'drracket:range-indentation for #lang-controlled block indentation

### DIFF
--- a/drracket/drracket/private/in-irl-namespace.rkt
+++ b/drracket/drracket/private/in-irl-namespace.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require racket/match
+         racket/math
          racket/class
          racket/contract/option
          racket/contract
@@ -170,6 +171,10 @@
                exact-nonnegative-integer?
                exact-nonnegative-integer?
                (or/c #f (listof (list/c exact-nonnegative-integer? string?)))))]
+    [(drracket:grouping-position)
+     (or/c #f
+           (-> natural? natural? (or/c 'up 'down 'backward 'forward)
+               (or/c #f #t natural?)))]
     [(drracket:keystrokes)
      ;; string? is too permissive; need racket/gui to publish
      ;; the actual contract (used on `map-function`)

--- a/drracket/drracket/private/in-irl-namespace.rkt
+++ b/drracket/drracket/private/in-irl-namespace.rkt
@@ -164,6 +164,12 @@
            (-> read-only-text/c
                exact-nonnegative-integer?
                (or/c #f exact-nonnegative-integer?)))]
+    [(drracket:range-indentation)
+     (or/c #f
+           (-> read-only-text/c
+               exact-nonnegative-integer?
+               exact-nonnegative-integer?
+               (or/c #f (listof (list/c exact-nonnegative-integer? string?)))))]
     [(drracket:keystrokes)
      ;; string? is too permissive; need racket/gui to publish
      ;; the actual contract (used on `map-function`)

--- a/drracket/drracket/private/insulated-read-language.rkt
+++ b/drracket/drracket/private/insulated-read-language.rkt
@@ -29,6 +29,7 @@ Will not work with the definitions text surrogate interposition that
   (or/c 'drracket:default-filters
         'drracket:default-extension
         'drracket:indentation
+        'drracket:range-indentation
         'drracket:keystrokes
         'drracket:show-big-defs/ints-labels
         'drracket:submit-predicate
@@ -207,6 +208,13 @@ Will not work with the definitions text surrogate interposition that
              an-irl
              (λ () #f)
              (λ () (val txt pos)))))]
+    [(drracket:range-indentation)
+     (and val
+          (λ (txt start-pos end-pos)
+            (call-in-irl-context/abort
+             an-irl
+             (λ () #f)
+             (λ () (val txt start-pos end-pos)))))]
     [(drracket:keystrokes)
      (for/list ([pr (in-list val)])
        (define key (list-ref pr 0))

--- a/drracket/drracket/private/insulated-read-language.rkt
+++ b/drracket/drracket/private/insulated-read-language.rkt
@@ -30,6 +30,7 @@ Will not work with the definitions text surrogate interposition that
         'drracket:default-extension
         'drracket:indentation
         'drracket:range-indentation
+        'drracket:grouping-position
         'drracket:keystrokes
         'drracket:show-big-defs/ints-labels
         'drracket:submit-predicate
@@ -215,6 +216,13 @@ Will not work with the definitions text surrogate interposition that
              an-irl
              (λ () #f)
              (λ () (val txt start-pos end-pos)))))]
+    [(drracket:grouping-position)
+     (and val
+          (λ (start-position limit-position direction)
+            (call-in-irl-context/abort
+             an-irl
+             (λ () #t)
+             (λ () (val start-position limit-position direction)))))]
     [(drracket:keystrokes)
      (for/list ([pr (in-list val)])
        (define key (list-ref pr 0))

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -65,4 +65,4 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.9")
+(define version "1.10")

--- a/drracket/info.rkt
+++ b/drracket/info.rkt
@@ -65,4 +65,4 @@
 
 (define pkg-authors '(robby))
 
-(define version "1.10")
+(define version "1.11")

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -43,6 +43,7 @@ DrRacket calls the language's @racket[read-language]'s
          @item{@language-info-ref[drracket:default-extension]}
          @item{@language-info-ref[drracket:indentation]}
          @item{@language-info-ref[drracket:range-indentation]}
+         @item{@language-info-ref[drracket:grouping-position]}
          @item{@language-info-ref[drracket:keystrokes]}
          @item{@language-info-ref[drracket:show-big-defs/ints-labels]}
          @item{@language-info-ref[drracket:opt-out-toolbar-buttons]}
@@ -137,6 +138,50 @@ These precise colors for these identifiers are controlled by the preferences dia
  The procedure's first argument will be the definitions text, the
  second will be the event object supplied from the GUI system
  and the result of the procedure is ignored.
+}
+
+@language-info-def[drracket:grouping-position]{
+
+ When a language's @racket[_get-info] procedure responds to
+ @racket['drracket:keystrokes], it is expected to return a
+ function that determines where positions relevant to the
+ nesting structure of the program appear. This function is
+ used for a number of motion and selection operations in the
+ editor, as well as determining where to flash to for closing
+ parentheses.
+
+ Specifically the result must be a function matching this
+ contract:
+ @racket[(-> natural?
+             natural?
+             (or/c 'up 'down 'backward 'forward)
+             (or/c #f #t natural?))]
+
+ Consider first the first and third argument. The first
+ argument indicates a position in the editor to start from
+ and the third argument is a direction to look. The result
+ return the position for the corresponding direction, where
+ the nesting structure of the program is viewed as a tree.
+ That is, if the third argument is @racket['up], the function
+ should return the position that goes up one layer in the
+ tree from the given position to the parent. Similarly
+ @racket['down] should return the position going on layer
+ deeper into that tree, going down to the first child. The
+ @racket['backward] and @racket['forward] arguments
+ correspond to position where we stay at the same level in
+ the tree, moving between siblings. The result should be
+ @racket[#f] when there is no corresponding position to move
+ to, e.g., when the current position has no children, no
+ parents, or no siblings in the corresponding direction.
+
+ The second argument is a limit. Positions smaller than the
+ limit should be ignored, so if the corresponding position
+ appears to be before the limit, return @racket[#f].
+
+ Finally, return @racket[#t] to get the default behavior,
+ namely motion in Racket-style s-expressions.
+
+ @history[#:added "1.11"]
 }
 
 @section{Filename Extensions}

--- a/drracket/scribblings/tools/lang-tools.scrbl
+++ b/drracket/scribblings/tools/lang-tools.scrbl
@@ -42,6 +42,7 @@ DrRacket calls the language's @racket[read-language]'s
 @itemize[@item{@language-info-ref[drracket:default-filters]}
          @item{@language-info-ref[drracket:default-extension]}
          @item{@language-info-ref[drracket:indentation]}
+         @item{@language-info-ref[drracket:range-indentation]}
          @item{@language-info-ref[drracket:keystrokes]}
          @item{@language-info-ref[drracket:show-big-defs/ints-labels]}
          @item{@language-info-ref[drracket:opt-out-toolbar-buttons]}
@@ -86,6 +87,34 @@ These precise colors for these identifiers are controlled by the preferences dia
  DrRacket uses the standard s-expression indentation rules.
 
  @history[#:added "1.3"]
+}
+
+@language-info-def[drracket:range-indentation]{
+ When a language's @racket[_get-info] procedure responds to @racket['drracket:range-indentation],
+ it is expected to return a function with this contract:
+ @racketblock[(-> (is-a?/c racket:text<%>)
+                  exact-nonnegative-integer?
+                  exact-nonnegative-integer?
+                  (or/c #f (listof (list/c exact-nonnegative-integer? string?))))]
+ The function is used to indent a range that potentially spans multiple lines in DrRacket.
+ It is called with the start and ending position of the range. The function is expected to return
+ either @racket[#f] or a list with an item for each line in the range. Returning @racket[#f]
+ falls back to iterating indentation over every line in the range (using @racket['drracket:indentation],
+ if available). Returning a list indicates an update for each corresponding line, where
+ a line update takes the form @racket[(list _delete-amount _insert-string)]:
+ first delete @racket[_delete-amount] items from the start of the line, and then
+ insert @racket[_insert-string] at the start of the line. If the returned list has fewer
+ items then the range of lines to indent, the list is effectively padded with @racket[(list 0 "")]
+ no-op items. If the list has more items than the range of lines to indent, the extra items
+ are ignored. Note that returning an empty list causes no lines to be updated, as opposed to
+ returning @racket[#f] to trigger a different indentation mechanism.
+
+ When both @racket['drracket:indentation] and @racket['drracket:range-indentation]
+ are available, the function for @racket['drracket:range-indentation] is called first---except
+ in the case of an implicit indentation from creating a newline, in which case only
+ @racket['drracket:indentation] is used.
+
+ @history[#:added "1.10"]
 }
 
 @section{Keystrokes}


### PR DESCRIPTION
For languages where there's not a single way to indent --- especially
where indentation can drive parsing instead of always the other way
around --- the indent operation might cycle through some
possibilities. In that case, multi-line indentation by indenting each
line separately does not work well. The 'drracket:range-indentation
configuration hook lets a language implement multi-line indentation
differently.